### PR TITLE
Fix overflowing underline on about page hyperlinks

### DIFF
--- a/src/components/about/About.js
+++ b/src/components/about/About.js
@@ -57,7 +57,7 @@ const About = () => (
               href={Variables.TWITTER_URL}
               rel="noopener noreferrer"
             >
-              Twitter &nbsp;
+              Twitter
             </a>
           </LinkStyle>
         </p>
@@ -74,7 +74,7 @@ const About = () => (
                 href="https://docs.google.com/forms/d/e/1FAIpQLSc_AnI5Ix4wySnFvio1PKrdJNmX86JU4oF2pEWKHp7HXjBZ4w/viewform"
                 rel="noopener noreferrer"
               >
-                here &nbsp;
+                here
               </a>
             </LinkStyle>
           </p>


### PR DESCRIPTION
#### What does this PR do?
Removes the hardcoded space that is causing an overflow of the hyperlink underline

#### Description of Task to be completed?
Fixes the overflowing underline on hyperlinks located on the about page

#### How should this be manually tested?
Go to the about page, check that the underlines on hyperlinks are the same width as the text

#### What are the relevant Trello Card stories? [ Trello Card Item ](https://trello.com/c/PxaSSqlQ/113-fix-underline-overflow-on-about-page-links)

#### Pull Request Type (check one)
- [ ] Feature
- [x] Bug Fixes
- [ ] Chore

#### Developer Checklist
- [x] New code has been scanned for ESlint issues
- [x] I have tested my code locally
- [x] I made sure that there are no other pull requests that solve for this issue
- [x] My code follows the same structure within the guidelines


#### Screenshots (if appropriate)
Before:
![image](https://user-images.githubusercontent.com/6531199/84092865-a67c3c80-a9c6-11ea-8a0f-51c8cdd0b0d2.png)

After:
![image](https://user-images.githubusercontent.com/6531199/84092853-9cf2d480-a9c6-11ea-9158-558ccd2bc46d.png)

